### PR TITLE
Remove files property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,6 @@
   "bin": {
     "clang-format": "./cli.js"
   },
-  "files": [
-    "clang-format-spawn.js",
-    "cli.js",
-    "index.js",
-    "result.js"
-  ],
   "dependencies": {
     "array-flat-polyfill": "^1.0.1",
     "commander": "^6.1.0"


### PR DESCRIPTION
This prevents npx from properly distributing the embedded binaries

Followup to #5 