### PR TITLE
Convert clang-format wrapper to a Promise-based API

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,6 +5,7 @@ const path = require("path");
 const { program } = require("commander");
 const { clangFormatter, walk } = require("./index");
 const { STATUS } = require("./result");
+const { version } = require("./package.json");
 
 async function run(directory, cmd) {
   const dir = directory || path.resolve(".");
@@ -48,7 +49,7 @@ async function run(directory, cmd) {
   const timer = setInterval(() => {}, 100);
   try {
     program
-      .version("0.2.0")
+      .version(version)
       .description(
         `Node.js runner for LLVM clang-format
 

--- a/format.js
+++ b/format.js
@@ -1,11 +1,11 @@
-const process_spawn = require("child_process").spawn;
+const spawn = require("child_process").spawn;
 const fs = require("fs").promises;
 const os = require("os");
 const path = require("path");
 
 const { ko } = require("./result");
 
-async function spawn(source, done, stdio) {
+async function format(source) {
   let executable;
   if (os.platform() === "win32") {
     executable = path.resolve(__dirname, "bin", "win32", "clang-format.exe");
@@ -24,18 +24,26 @@ async function spawn(source, done, stdio) {
     if (err) {
       return Promise.reject(ko(executable, err));
     }
-    const process = process_spawn(executable, [source], { stdio: stdio });
-    process.on("close", (exitCode) => {
-      if (exitCode) {
-        done(`clang-format exited with error code ${exitCode}`);
-      } else {
-        done(null);
-      }
+    let formatted = "";
+
+    const stdio = ["ignore", "pipe", process.stderr];
+    const clangFormat = spawn(executable, [source], { stdio: stdio });
+    clangFormat.stdout.on("data", (data) => {
+      formatted += data.toString();
     });
-    return Promise.resolve(process);
+
+    return new Promise((resolve, reject) => {
+      clangFormat.on("close", (exitCode) => {
+        if (exitCode) {
+          reject(ko(source, `clang-format exited with error code ${exitCode}`));
+        } else {
+          resolve(formatted);
+        }
+      });
+    });
   } catch (err) {
     return Promise.reject(ko(null, err));
   }
 }
 
-module.exports = spawn;
+module.exports = format;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@artichoke/clang-format",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artichoke/clang-format",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Artichoke Ruby clang-format runner",
   "keywords": [


### PR DESCRIPTION
Change the implementation to return a `Promise` of formatted source code
rather than access to a spawned process.

This significantly simplifies the `index.js` runners.

Bump version to 0.3.0.