### PR TITLE
Fix quoting in prettier invocation for fmt npm run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   },
   "scripts": {
-    "fmt": "npx prettier --write '**/*'",
+    "fmt": "npx prettier --write \"**/*\"",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint . --fix"
   }


### PR DESCRIPTION
Windows requires the glob to be double quoted.