### PR TITLE
Add GitHub Actions workflow to run markdown-link-check

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,0 +1,16 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "img.shields.io"
+    }
+  ],
+  "replacementPatterns": [],
+  "httpHeaders": [
+    {
+      "urls": ["https://crates.io"],
+      "headers": {
+        "Accept": "text/html"
+      }
+    }
+  ]
+}

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,36 @@
+---
+"on":
+  push:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  pull_request:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  schedule:
+    - cron: "0 0 * * TUE"
+name: Markdown Links Check
+jobs:
+  check-links:
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Purge vendored sources
+        run: |
+          shopt -s globstar
+          rm -rf **/vendor/*/
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        # checks all markdown files from /docs including all subfolders
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          config-file: ".github/markdown-link-check.json"
+          folder-path: "."

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -22,13 +22,11 @@ jobs:
     name: Check links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Purge vendored sources
-        run: |
-          shopt -s globstar
-          rm -rf **/vendor/*/
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        # checks all markdown files from /docs including all subfolders
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Check for broken links in markdown files
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "fmt": "npx prettier --write \"**/*\"",
     "lint": "npx eslint .",
-    "lint:fix": "npx eslint . --fix"
+    "lint:fix": "npx eslint . --fix",
+    "release:markdown_link_check": "find . -name '*.md' -and -not -path '*/node_modules/*' | sort | xargs -n1 npx markdown-link-check --config .github/markdown-link-check.json"
   }
 }


### PR DESCRIPTION
Artichoke already incorporates this tool in the `Rakefile` as the
`release:markdown_link_check` task, but it is slow and doesn't get
regularly run.

Incorporate this into CI such that links are checked on every PR that
touches markdown files and on a weekly cron with the same cadence as the
audit workflow.