### PR TITLE
Show version of embedded `clang-format` when invoking `--version`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@artichokeruby/clang-format",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@artichokeruby/clang-format",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artichokeruby/clang-format",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "description": "Artichoke Ruby clang-format runner",
   "keywords": [

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,7 @@ const path = require("node:path");
 
 const { program } = require("commander");
 
+const { version: clangFormatVersion } = require("./embedded-clang-format");
 const formatter = require("./index");
 const { walk } = require("./fs");
 const { STATUS, ko } = require("./result");
@@ -61,8 +62,9 @@ const run = async (directory, options, _command) => {
 
 const main = async () => {
   try {
+    const cliVersion = `artichoke/clang-format version ${version}\n${await clangFormatVersion()}`;
     program
-      .version(version)
+      .version(cliVersion)
       .description(
         `Node.js runner for LLVM clang-format
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 const fs = require("node:fs/promises");
 const path = require("node:path");
 
-const format = require("./format");
+const { format } = require("./embedded-clang-format");
 const { formattableSourcesFrom } = require("./fs");
 const { ok, ko } = require("./result");
 


### PR DESCRIPTION
When invoking the `--version` flag to the `commander` CLI, show the
version of the embedded `clang-format` binary.

Bump the version of this package to v0.10.0.