### PR TITLE
Update embedded bins README.md

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -3,7 +3,7 @@
 This directory includes pre-built binaries for `clang-format` on the following
 platforms:
 
-- Apple x86_64
+- Apple x86_64, arm64
 - Linux x86_64
 - Windows win32
 


### PR DESCRIPTION
Document that Apple arm64 binaries are included in the distribution.