### PR TITLE
Add support for specifying ignore rules in `.clang-format-ignore` file using gitignore syntax

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,6 @@
+.git
+build
+emsdk
+node_modules
+target
+vendor

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run locally with npx and inferred target directory
         if: runner.os != 'Windows'
-        run: npx -p .. clang-format --check
+        run: npx -p .. clang-format --check --ignore-path ../.clang-format-ignore
         working-directory: "artichoke-integration-test"
 
   js:

--- a/bin/clang-format.js
+++ b/bin/clang-format.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-"use strict";
-
 import main from "../src/cli.js";
 
 await main();

--- a/bin/clang-format.js
+++ b/bin/clang-format.js
@@ -2,8 +2,6 @@
 
 "use strict";
 
-const main = require("../src/cli");
+import main from "../src/cli.js";
 
-(async () => {
-  await main();
-})();
+await main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^11.1.0",
-        "ignore": "^5.3.0"
+        "ignore": "^5.3.0",
+        "p-limit": "^5.0.0"
       },
       "bin": {
         "clang-format": "bin/clang-format.js"
@@ -866,6 +867,35 @@
       }
     },
     "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -880,14 +910,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -1162,12 +1189,11 @@
       "dev": true
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,16 +21,18 @@
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -43,16 +45,18 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -73,16 +77,18 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.1",
         "debug": "^4.1.1",
@@ -94,8 +100,9 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -106,13 +113,15 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "2.0.1",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -123,16 +132,18 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -143,13 +154,15 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -159,16 +172,18 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -182,16 +197,18 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -204,18 +221,21 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -223,16 +243,18 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -246,8 +268,9 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -257,25 +280,29 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/commander": {
       "version": "11.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -287,8 +314,9 @@
     },
     "node_modules/debug": {
       "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -303,13 +331,15 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -319,8 +349,9 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -330,8 +361,9 @@
     },
     "node_modules/eslint": {
       "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -384,8 +416,9 @@
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -399,8 +432,9 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -410,8 +444,9 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -426,8 +461,9 @@
     },
     "node_modules/esquery": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -437,8 +473,9 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -448,47 +485,54 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -498,8 +542,9 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -513,8 +558,9 @@
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -526,18 +572,21 @@
     },
     "node_modules/flatted": {
       "version": "3.2.9",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -555,8 +604,9 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -566,8 +616,9 @@
     },
     "node_modules/globals": {
       "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -580,29 +631,33 @@
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ignore": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -616,16 +671,18 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -633,21 +690,24 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -657,21 +717,24 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -681,31 +744,36 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -716,8 +784,9 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -730,13 +799,15 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -746,26 +817,30 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/optionator": {
       "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
@@ -780,8 +855,9 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -794,8 +870,9 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -808,8 +885,9 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -819,40 +897,45 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -865,14 +948,17 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
         {
@@ -887,21 +973,22 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/reusify": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -909,8 +996,9 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -923,6 +1011,8 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
         {
@@ -938,15 +1028,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -956,16 +1046,18 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -975,8 +1067,9 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -986,8 +1079,9 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -997,13 +1091,15 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -1013,8 +1109,9 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -1024,16 +1121,18 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -1046,13 +1145,15 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "commander": "^11.1.0"
+        "commander": "^11.1.0",
+        "ignore": "^5.3.0"
       },
       "bin": {
         "clang-format": "bin/clang-format.js"
@@ -648,7 +649,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
       "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@artichokeruby/clang-format",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@artichokeruby/clang-format",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
+        "chalk": "^5.3.0",
         "commander": "^11.1.0",
         "ignore": "^5.3.0"
       },
@@ -252,16 +253,11 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -441,6 +437,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
       "eslint:recommended"
     ],
     "parserOptions": {
-      "ecmaVersion": 8
+      "ecmaVersion": 2022,
+      "sourceType": "module"
     },
     "rules": {
       "no-unused-vars": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^11.1.0",
-    "ignore": "^5.3.0"
+    "ignore": "^5.3.0",
+    "p-limit": "^5.0.0"
   },
   "devDependencies": {
     "eslint": "8.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@artichokeruby/clang-format",
   "version": "0.16.0",
+  "type": "module",
   "private": true,
   "description": "Artichoke Ruby clang-format runner",
   "keywords": [
@@ -22,6 +23,7 @@
     "clang-format": "bin/clang-format.js"
   },
   "dependencies": {
+    "chalk": "^5.3.0",
     "commander": "^11.1.0",
     "ignore": "^5.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "clang-format": "bin/clang-format.js"
   },
   "dependencies": {
-    "commander": "^11.1.0"
+    "commander": "^11.1.0",
+    "ignore": "^5.3.0"
   },
   "devDependencies": {
     "eslint": "8.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artichokeruby/clang-format",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "description": "Artichoke Ruby clang-format runner",
   "keywords": [

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,116 +3,82 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import chalk from "chalk";
 import { program } from "commander";
 import ignore from "ignore";
 
-import { version as clangFormatVersion } from "./embedded-clang-format.js";
+import { clangFormatVersion } from "./embedded-clang-format.js";
 import formatter from "./index.js";
-import { walk } from "./fs.js";
-import { STATUS } from "./result.js";
+import { getFiles } from "./fs.js";
+import { STATUS, reportError, reportOk } from "./result.js";
 
 const VERSION = "0.16.0";
 
-const getFiles = async (dir, exts) => {
-  const files = [];
-  const errors = [];
-
-  for (const candidate of await walk(dir)) {
-    if (candidate.status === STATUS.ok) {
-      const p = candidate.path;
-      const ext = path.extname(p);
-      if (exts.has(ext)) {
-        files.push(p);
-      }
-      continue;
-    }
-    if (candidate.path) {
-      errors.push({ type: "warn", path });
-    }
-    if (candidate.err) {
-      errors.push({ type: "error", error: candidate.err });
-    }
-  }
-  if (errors.length > 0) {
-    return Promise.reject(errors);
-  }
-  return files;
-};
-
-const getIgnore = async (ignoreFilePath) => {
+async function getIgnore(ignoreFilePath) {
   try {
     const content = await fs.readFile(ignoreFilePath, "utf8");
     const rules = content.split(/\r?\n/);
     return ignore().add(rules);
-  } catch (_err) {
+  } catch {
     return ignore();
   }
-};
+}
 
-const formatSources = async (dir, sources, check) => {
-  if (check) {
-    return formatter.check(dir).run(sources);
-  } else {
-    return formatter.format(dir).run(sources);
-  }
-};
-
-const run = async (directory, options, _command) => {
+async function runCli(directory, options) {
   const dir = path.resolve(directory || ".");
   const exts = new Set(options.ext.split(","));
   const files = [];
 
   try {
-    const f = await getFiles(dir, exts);
-    files.push(...f);
+    files.push(...(await getFiles(dir, exts)));
   } catch (err) {
+    console.debug(err);
     for (const result of err) {
-      if (result.type === "warn") {
-        console.log(chalk.red.bold("KO") + `: ${result.path}`);
-      }
-      if (result.type === "error") {
-        console.error(result.err);
-      }
+      reportError(result);
     }
-    process.exit(1);
+    return 1;
   }
 
   const ig = await getIgnore(options.ignorePath);
   const sources = files
-    .map((file) => path.relative(dir, file))
     .filter(ig.createFilter())
-    .map((file) => path.join(dir, file));
+    .map((file) => path.join(dir, file))
+    .map((file) => path.resolve(file));
 
-  const results = await formatSources(dir, sources, options.check);
+  const results = await formatter.execute(dir, sources, options.check);
 
-  let failed = false;
-  for (const result of results) {
-    if (result.status === STATUS.ok) {
-      console.log(chalk.green.bold("OK") + `: ${result.path}`);
+  let exitCode = 0;
+  for (let result of results) {
+    if (result.status === "rejected") {
+      reportError(ko(null, result.reason));
+      exitCode = 1;
       continue;
     }
-    if (result.path) {
-      console.log(chalk.red.bold("KO") + `: ${result.path}`);
+
+    result = result.value;
+    if (result.status === STATUS.failed) {
+      reportError(result);
+      exitCode = 1;
+      continue;
     }
-    if (result.err) {
-      console.error(result.err);
-    }
-    failed = true;
+
+    reportOk(result);
   }
 
-  if (failed) {
+  return exitCode;
+}
+
+export default async function main() {
+  const clangFormatVer = await clangFormatVersion();
+  if (clangFormatVer.status === STATUS.failed) {
+    reportError(clangFormatVer);
     process.exit(1);
   }
-};
+  const cliVersion = `artichoke/clang-format version ${VERSION}\n${clangFormatVer.version}`;
 
-const main = async () => {
-  try {
-    const cliVersion = `artichoke/clang-format version ${VERSION}\n${await clangFormatVersion()}`;
-    program
-      .version(cliVersion)
-      .description(
-        `Node.js runner for LLVM clang-format
+  program
+    .version(cliVersion)
+    .description(
+      `Node.js runner for LLVM clang-format
 
 clang-format is a tool to format C code.
 
@@ -122,30 +88,34 @@ Any clang-format configuration present on the filesystem will be honored.
 --check mode is suitable for CI. --check does not attempt to format and instead
 exits with a non-zero status code if the source code on disk does not match the
 enforced style.`,
-      )
-      .option(
-        "-c, --check",
-        `check if the given files are formatted. Exit with a non-
+    )
+    .option(
+      "-c, --check",
+      `check if the given files are formatted. Exit with a non-
 zero status code if any formatting errors are found.`,
-      )
-      .option(
-        "--ext <extensions>",
-        "specify formattable file extensions",
-        ".c,.cc,.cpp,.h",
-      )
-      .option(
-        "--ignore-path <path>",
-        "specify path of ignore file",
-        ".clang-format-ignore",
-      )
-      .arguments("[directory]")
-      .action(run);
-    await program.parseAsync(process.argv);
+    )
+    .option(
+      "--ext <extensions>",
+      "specify formattable file extensions",
+      ".c,.cc,.cpp,.h",
+    )
+    .option(
+      "--ignore-path <path>",
+      "specify path of ignore file",
+      ".clang-format-ignore",
+    )
+    .arguments("[directory]");
+
+  program.parse();
+  const options = program.opts();
+  const dir = program.args[0];
+
+  try {
+    const exitCode = await runCli(dir, options);
+    process.exit(exitCode);
   } catch (err) {
     console.error("Error: Unhandled exception");
     console.error(err);
     process.exit(1);
   }
-};
-
-export default main;
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,9 +13,13 @@ import { STATUS, reportError, reportOk } from "./result.js";
 
 const VERSION = "0.16.0";
 
-async function getIgnore(ignoreFilePath) {
+async function getIgnore(options) {
+  if (!options.ignore) {
+    return ignore();
+  }
+
   try {
-    const content = await fs.readFile(ignoreFilePath, "utf8");
+    const content = await fs.readFile(options.ignorePath, "utf8");
     const rules = content.split(/\r?\n/);
     return ignore().add(rules);
   } catch {
@@ -38,7 +42,7 @@ async function runCli(directory, options) {
     return 1;
   }
 
-  const ig = await getIgnore(options.ignorePath);
+  const ig = await getIgnore(options);
   const sources = files
     .filter(ig.createFilter())
     .map((file) => path.join(dir, file))
@@ -104,6 +108,7 @@ zero status code if any formatting errors are found.`,
       "specify path of ignore file",
       ".clang-format-ignore",
     )
+    .option("--no-ignore", "disable use of ignore files and patterns")
     .arguments("[directory]");
 
   program.parse();

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /* eslint-disable no-console */
 
 import fs from "node:fs/promises";

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ import ignore from "ignore";
 import { version as clangFormatVersion } from "./embedded-clang-format.js";
 import formatter from "./index.js";
 import { walk } from "./fs.js";
-import { STATUS, ko } from "./result.js";
+import { STATUS } from "./result.js";
 
 const VERSION = "0.16.0";
 
@@ -29,11 +29,11 @@ const getFiles = async (dir, exts) => {
       }
       continue;
     }
-    if (result.path) {
+    if (candidate.path) {
       errors.push({ type: "warn", path });
     }
-    if (result.err) {
-      errors.push({ type: "error", error: result.error });
+    if (candidate.err) {
+      errors.push({ type: "error", error: candidate.err });
     }
   }
   if (errors.length > 0) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,18 +2,19 @@
 
 /* eslint-disable no-console */
 
-const fs = require("node:fs/promises");
-const path = require("node:path");
+import fs from "node:fs/promises";
+import path from "node:path";
 
-const { program } = require("commander");
-const ignore = require("ignore");
+import chalk from "chalk";
+import { program } from "commander";
+import ignore from "ignore";
 
-const { version: clangFormatVersion } = require("./embedded-clang-format");
-const formatter = require("./index");
-const { walk } = require("./fs");
-const { STATUS, ko } = require("./result");
+import { version as clangFormatVersion } from "./embedded-clang-format.js";
+import formatter from "./index.js";
+import { walk } from "./fs.js";
+import { STATUS, ko } from "./result.js";
 
-const { version } = require("../package.json");
+const VERSION = "0.16.0";
 
 const getFiles = async (dir, exts) => {
   const files = [];
@@ -68,10 +69,9 @@ const run = async (directory, options, _command) => {
     const f = await getFiles(dir, exts);
     files.push(...f);
   } catch (err) {
-    console.debug(err);
     for (const result of err) {
       if (result.type === "warn") {
-        console.warn(`KO: ${result.path}`);
+        console.log(chalk.red.bold("KO") + `: ${result.path}`);
       }
       if (result.type === "error") {
         console.error(result.err);
@@ -91,11 +91,11 @@ const run = async (directory, options, _command) => {
   let failed = false;
   for (const result of results) {
     if (result.status === STATUS.ok) {
-      console.log(`OK: ${result.path}`);
+      console.log(chalk.green.bold("OK") + `: ${result.path}`);
       continue;
     }
     if (result.path) {
-      console.warn(`KO: ${result.path}`);
+      console.log(chalk.red.bold("KO") + `: ${result.path}`);
     }
     if (result.err) {
       console.error(result.err);
@@ -110,7 +110,7 @@ const run = async (directory, options, _command) => {
 
 const main = async () => {
   try {
-    const cliVersion = `artichoke/clang-format version ${version}\n${await clangFormatVersion()}`;
+    const cliVersion = `artichoke/clang-format version ${VERSION}\n${await clangFormatVersion()}`;
     program
       .version(cliVersion)
       .description(
@@ -150,4 +150,4 @@ zero status code if any formatting errors are found.`,
   }
 };
 
-module.exports = main;
+export default main;

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,7 +9,7 @@ import ignore from "ignore";
 import { clangFormatVersion } from "./embedded-clang-format.js";
 import formatter from "./index.js";
 import { getFiles } from "./fs.js";
-import { STATUS, reportError, reportOk } from "./result.js";
+import { STATUS, reportError, reportOk, ko } from "./result.js";
 
 const VERSION = "0.16.0";
 

--- a/src/embedded-clang-format.js
+++ b/src/embedded-clang-format.js
@@ -55,7 +55,7 @@ export async function format(source) {
       formatted = Buffer.concat([formatted, data]);
     });
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       let wasError = false;
 
       clangFormat.on("error", (err) => {
@@ -104,7 +104,7 @@ export async function clangFormatVersion() {
       version = Buffer.concat([version, data]);
     });
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       let wasError = false;
 
       clangFormat.on("error", (err) => {

--- a/src/embedded-clang-format.js
+++ b/src/embedded-clang-format.js
@@ -8,7 +8,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { STATUS, ok, ko } from "./result.js";
-import { dirname } from "path";
 
 const binpath = async () => {
   const dir = path.dirname(fileURLToPath(import.meta.url));

--- a/src/embedded-clang-format.js
+++ b/src/embedded-clang-format.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { Buffer } from "node:buffer";
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";

--- a/src/embedded-clang-format.js
+++ b/src/embedded-clang-format.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { Buffer } = require("node:buffer");
 const { spawn } = require("node:child_process");
 const fs = require("node:fs/promises");
 const os = require("node:os");
@@ -46,12 +47,13 @@ const format = async (source) => {
       return Promise.reject(result);
     }
     const executable = result.path;
-    let formatted = "";
+
+    let formatted = Buffer.alloc(0);
 
     const stdio = ["ignore", "pipe", process.stderr];
     const clangFormat = spawn(executable, [source], { stdio: stdio });
     clangFormat.stdout.on("data", (data) => {
-      formatted += data.toString();
+      formatted = Buffer.concat([formatted, data]);
     });
 
     return new Promise((resolve, reject) => {
@@ -125,9 +127,7 @@ const version = async () => {
   }
 };
 
-module.exports = Object.freeze(
-  Object.assign(Object.create(null), {
+module.exports = {
     format,
     version,
-  }),
-);
+  };

--- a/src/embedded-clang-format.js
+++ b/src/embedded-clang-format.js
@@ -1,26 +1,24 @@
 "use strict";
 
-const { Buffer } = require("node:buffer");
-const { spawn } = require("node:child_process");
-const fs = require("node:fs/promises");
-const os = require("node:os");
-const path = require("node:path");
+import { Buffer } from "node:buffer";
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const { STATUS, ok, ko } = require("./result");
+import { STATUS, ok, ko } from "./result.js";
+import { dirname } from "path";
 
 const binpath = async () => {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+
   let executable;
   if (os.platform() === "win32") {
-    executable = path.resolve(
-      __dirname,
-      "..",
-      "bin",
-      "win32",
-      "clang-format.exe",
-    );
+    executable = path.resolve(dir, "..", "bin", "win32", "clang-format.exe");
   } else {
     executable = path.resolve(
-      __dirname,
+      dir,
       "..",
       "bin",
       os.platform(),
@@ -127,7 +125,4 @@ const version = async () => {
   }
 };
 
-module.exports = {
-    format,
-    version,
-  };
+export { format, version };

--- a/src/embedded-clang-format.js
+++ b/src/embedded-clang-format.js
@@ -7,7 +7,16 @@ import { fileURLToPath } from "node:url";
 
 import { STATUS, ok, ko } from "./result.js";
 
-const binpath = async () => {
+async function isExecutable(file) {
+  try {
+    await fs.access(file, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function binpath() {
   const dir = path.dirname(fileURLToPath(import.meta.url));
 
   let executable;
@@ -24,29 +33,24 @@ const binpath = async () => {
     );
   }
 
-  try {
-    const err = await fs.access(executable, fs.F_OK);
-    if (err) {
-      return Promise.reject(ko(executable, err));
-    }
-    return Promise.resolve(ok(executable));
-  } catch (err) {
-    return Promise.reject(ko(executable, err));
+  if (await isExecutable(executable)) {
+    return ok(executable);
   }
-};
+  return ko(executable);
+}
 
-const format = async (source) => {
+export async function format(source) {
+  const result = await binpath();
+  if (result.status === STATUS.failed) {
+    return result;
+  }
+  const executable = result.path;
+
+  let formatted = Buffer.alloc(0);
   try {
-    const result = await binpath();
-    if (result.status === STATUS.failed) {
-      return Promise.reject(result);
-    }
-    const executable = result.path;
-
-    let formatted = Buffer.alloc(0);
-
     const stdio = ["ignore", "pipe", process.stderr];
     const clangFormat = spawn(executable, [source], { stdio: stdio });
+
     clangFormat.stdout.on("data", (data) => {
       formatted = Buffer.concat([formatted, data]);
     });
@@ -55,71 +59,81 @@ const format = async (source) => {
       let wasError = false;
 
       clangFormat.on("error", (err) => {
-        reject(ko(source, err));
+        resolve(ko(source, err));
         // `close` event is triggered after `error`. Track that we have already
-        // rejected the promise so we can short circuit in the `close` handler.
+        // resolved the promise so we can short circuit in the `close` handler.
         wasError = true;
       });
 
       clangFormat.on("close", (exitCode) => {
-        // The promise was already rejected in the `error` handler, so do
-        // nothing.
+        // The promise was already resolved with `ko` in the `error` handler, so
+        // do nothing.
         if (wasError) {
           return;
         }
+
         if (exitCode) {
-          reject(ko(source, `clang-format exited with error code ${exitCode}`));
-        } else {
-          resolve(formatted);
+          const result = ko(
+            source,
+            `clang-format exited with non-zero status code (${exitCode}) for ${source}`,
+          );
+          resolve(result);
+          return;
         }
+
+        resolve(ok(source, { content: formatted }));
       });
     });
   } catch (err) {
-    return Promise.reject(ko(null, err));
+    return ko(source, err);
   }
-};
+}
 
-const version = async () => {
+export async function clangFormatVersion() {
+  const result = await binpath();
+  if (result.status === STATUS.failed) {
+    return result;
+  }
+  const executable = result.path;
+
+  let version = Buffer.alloc(0);
   try {
-    const result = await binpath();
-    if (result.status === STATUS.failed) {
-      return Promise.reject(result);
-    }
-    const executable = result.path;
-    let version = "";
-
     const stdio = ["ignore", "pipe", process.stderr];
     const clangFormat = spawn(executable, ["--version"], { stdio: stdio });
     clangFormat.stdout.on("data", (data) => {
-      version += data.toString();
+      version = Buffer.concat([version, data]);
     });
 
     return new Promise((resolve, reject) => {
       let wasError = false;
 
       clangFormat.on("error", (err) => {
-        reject(ko(null, err));
+        resolve(ko(null, err));
         // `close` event is triggered after `error`. Track that we have already
-        // rejected the promise so we can short circuit in the `close` handler.
+        // resolved the promise so we can short circuit in the `close` handler.
         wasError = true;
       });
 
       clangFormat.on("close", (exitCode) => {
-        // The promise was already rejected in the `error` handler, so do
-        // nothing.
+        // The promise was already resolved with `ko` in the `error` handler, so
+        // do nothing.
         if (wasError) {
           return;
         }
+
         if (exitCode) {
-          reject(ko(null, `clang-format exited with error code ${exitCode}`));
-        } else {
-          resolve(version.trim());
+          const result = ko(
+            null,
+            `clang-format --version exited with non-zero status code (${exitCode})`,
+          );
+          resolve(result);
+          return;
         }
+
+        resolve(ok(null, { version: version.toString().trim() }));
       });
     });
   } catch (err) {
-    return Promise.reject(ko(null, err));
+    return ko(null, err);
   }
-};
-
-export { format, version };
+}

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,31 +1,65 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { ok, ko } from "./result.js";
+import { ok, ko, STATUS } from "./result.js";
 
-const walk = async (dir) => {
+async function walk(dir, accumulator) {
+  const files = [];
+
   try {
-    const files = await fs.readdir(dir);
-    const children = files.map(async (file) => {
-      try {
-        const filepath = path.join(dir, file);
-        const stats = await fs.stat(filepath);
-        if (stats.isDirectory()) {
-          return walk(filepath);
-        }
-        if (stats.isFile()) {
-          return Promise.resolve(ok(filepath));
-        }
-        return Promise.reject(ko(filepath));
-      } catch (err) {
-        return Promise.reject(ko(file, err));
-      }
-    });
-    const listing = Promise.all(children);
-    return listing.then((entries) => entries.flat(Infinity));
+    const f = await fs.readdir(dir);
+    files.push(...f);
   } catch (err) {
-    return Promise.reject(ko(null, err));
+    return ko(dir, err);
   }
-};
 
-export { walk };
+  for (const filename of files) {
+    const p = path.join(dir, filename);
+
+    try {
+      const stats = await fs.stat(p);
+
+      if (stats.isDirectory()) {
+        await walk(p, accumulator);
+        continue;
+      }
+
+      if (stats.isFile()) {
+        accumulator.push(ok(p));
+        continue;
+      }
+
+      accumulator.push(ko(p));
+    } catch (err) {
+      accumulator.push(ko(p, err));
+    }
+  }
+}
+
+export async function getFiles(dir, exts) {
+  const files = [];
+  const errors = [];
+
+  const acc = [];
+  await walk(dir, acc);
+
+  for (const result of acc) {
+    if (result.status === STATUS.failed) {
+      errors.push(result);
+      continue;
+    }
+
+    const file = path.relative(dir, result.path);
+    const ext = path.extname(file);
+
+    if (exts.has(ext)) {
+      files.push(file);
+    }
+  }
+
+  if (errors.length > 0) {
+    return Promise.reject(errors);
+  }
+
+  return files;
+}

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const fs = require("node:fs/promises");
-const path = require("node:path");
+import fs from "node:fs/promises";
+import path from "node:path";
 
-const { ok, ko } = require("./result");
+import { ok, ko } from "./result.js";
 
 const walk = async (dir) => {
   try {
@@ -30,6 +30,4 @@ const walk = async (dir) => {
   }
 };
 
-module.exports = {
-  walk,
-};
+export { walk };

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import fs from "node:fs/promises";
 import path from "node:path";
 

--- a/src/fs.js
+++ b/src/fs.js
@@ -13,6 +13,7 @@ async function walk(dir, accumulator) {
     return ko(dir, err);
   }
 
+  const descend = [];
   for (const filename of files) {
     const p = path.join(dir, filename);
 
@@ -20,7 +21,7 @@ async function walk(dir, accumulator) {
       const stats = await fs.stat(p);
 
       if (stats.isDirectory()) {
-        await walk(p, accumulator);
+        descend.push(walk(p, accumulator));
         continue;
       }
 
@@ -34,6 +35,7 @@ async function walk(dir, accumulator) {
       accumulator.push(ko(p, err));
     }
   }
+  await Promise.allSettled(descend);
 }
 
 export async function getFiles(dir, exts) {

--- a/src/fs.js
+++ b/src/fs.js
@@ -5,22 +5,10 @@ const path = require("node:path");
 
 const { ok, ko } = require("./result");
 
-const IGNORE_DIRECTORIES = Object.freeze([
-  ".git",
-  "build",
-  "emsdk",
-  "node_modules",
-  "target",
-  "vendor",
-]);
-
 const walk = async (dir) => {
   try {
     const files = await fs.readdir(dir);
-    const permissible = files.filter(
-      (file) => !IGNORE_DIRECTORIES.includes(file),
-    );
-    const children = permissible.map(async (file) => {
+    const children = files.map(async (file) => {
       try {
         const filepath = path.join(dir, file);
         const stats = await fs.stat(filepath);
@@ -42,25 +30,6 @@ const walk = async (dir) => {
   }
 };
 
-const filesWithExtension = (files, ext) =>
-  files.filter((file) => {
-    const extname = path.extname(file);
-    return ext === extname;
-  });
-
-const formattableSourcesFrom = (files) => [
-  ...filesWithExtension(files, ".c"),
-  ...filesWithExtension(files, ".cc"),
-  ...filesWithExtension(files, ".cpp"),
-  ...filesWithExtension(files, ".h"),
-  ...filesWithExtension(files, ".hpp"),
-  ...filesWithExtension(files, ".m"),
-  ...filesWithExtension(files, ".mm"),
-];
-
-module.exports = Object.freeze(
-  Object.assign(Object.create(null), {
-    formattableSourcesFrom,
-    walk,
-  }),
-);
+module.exports = {
+  walk,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 "use strict";
 
-const { Buffer } = require("node:buffer");
-const fs = require("node:fs/promises");
-const path = require("node:path");
+import { Buffer } from "node:buffer";
+import fs from "node:fs/promises";
+import path from "node:path";
 
-const { format } = require("./embedded-clang-format");
-const { ok, ko } = require("./result");
+import { format } from "./embedded-clang-format.js";
+import { ok, ko } from "./result.js";
 
 const formatSource = async (source, relative) => {
   try {
@@ -44,7 +44,7 @@ const checkSource = async (source, relative) => {
   }
 };
 
-module.exports = {
+export default {
   check(sourceRoot) {
     return {
       sourceRoot,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { Buffer } from "node:buffer";
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import { Buffer } from "node:buffer";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import pLimit from "p-limit";
+
 import { format } from "./embedded-clang-format.js";
 import { ok, ko } from "./result.js";
 
@@ -48,9 +50,11 @@ export default {
       sourceRoot,
 
       async run(sources) {
+        const limit = pLimit(8);
+
         const promises = sources.map((source) => {
           const relative = path.relative(this.sourceRoot, source);
-          return checkSource(source, relative);
+          return limit(() => checkSource(source, relative));
         });
         return Promise.all(promises);
       },
@@ -62,9 +66,11 @@ export default {
       sourceRoot,
 
       async run(sources) {
+        const limit = pLimit(8);
+
         const promises = sources.map((source) => {
           const relative = path.relative(this.sourceRoot, source);
-          return formatSource(source, relative);
+          return limit(() => formatSource(source, relative));
         });
         return Promise.all(promises);
       },

--- a/src/result.js
+++ b/src/result.js
@@ -24,8 +24,4 @@ const ko = (path, err = null) =>
     }),
   );
 
-module.exports = {
-  STATUS,
-  ok,
-  ko,
-};
+export { STATUS, ok, ko };

--- a/src/result.js
+++ b/src/result.js
@@ -1,25 +1,49 @@
-const STATUS = Object.freeze(
+import chalk from "chalk";
+
+export const STATUS = Object.freeze(
   Object.assign(Object.create(null), {
     ok: "ok",
     failed: "failed",
   }),
 );
 
-const ok = (path) =>
-  Object.freeze(
-    Object.assign(Object.create(null), {
-      path,
-      status: STATUS.ok,
-    }),
+export function ok(path, extra = null) {
+  return Object.freeze(
+    Object.assign(
+      Object.create(null),
+      {
+        path,
+        status: STATUS.ok,
+      },
+      extra || {},
+    ),
   );
+}
 
-const ko = (path, err = null) =>
-  Object.freeze(
+export function ko(path, err = null) {
+  return Object.freeze(
     Object.assign(Object.create(null), {
       path,
       status: STATUS.failed,
       err,
     }),
   );
+}
 
-export { STATUS, ok, ko };
+export function reportError(result) {
+  if (result.status !== STATUS.failed) {
+    throw new Error("attempted to report error for success");
+  }
+  if (result.err) {
+    console.log(chalk.red.bold("KO") + `: ${result.path} (ERR: ${result.err})`);
+    return;
+  }
+  console.log(chalk.red.bold("KO") + `: ${result.path}`);
+}
+
+export function reportOk(result) {
+  if (result.status !== STATUS.ok) {
+    throw new Error("attempted to report success for failure");
+  }
+  console.log(chalk.green.bold("OK") + `: ${result.path}`);
+}

--- a/src/result.js
+++ b/src/result.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const STATUS = Object.freeze(
   Object.assign(Object.create(null), {
     ok: "ok",

--- a/src/result.js
+++ b/src/result.js
@@ -24,10 +24,8 @@ const ko = (path, err = null) =>
     }),
   );
 
-module.exports = Object.freeze(
-  Object.assign(Object.create(null), {
-    STATUS,
-    ok,
-    ko,
-  }),
-);
+module.exports = {
+  STATUS,
+  ok,
+  ko,
+};


### PR DESCRIPTION
Closes #55.

This is a fairly large rewrite of this small package.

The flow of the CLI program is reworked to the following stages:

- Walk given directory, recursing into all directories, and yielding paths to files that end in the given extensions.
- Relativize the yielded paths to the given directory, filter with `ignore`, and absolutize the paths.
- Format or check sources.
- Print report.

These refactors contain many performance optimizations which make file path walking and path filtering much faster.

To support this new flow, this PR adds two new options to the CLI, in the style of eslint:

- `--ext`, which specifies the comma-separated set of file extensions to include for formatting. Default: .c,.cc,.cpp,.h
- `--ignore-path`, which specifies the path to a clang-format ignore file. Default: .clang-format-ignore.

The `.clang-format-ignore` file is parsed with the `ignore` npm package, which is compatible with the gitignore spec.

This PR also adds the ESM-only chalk v5 dependency for slightly nicer colorized reporting. I upgraded the package to ESM (mostly by converting `require` to `import` and changing `export` syntax; I also had to replace `__dirname`).

## `clang-format --help`

```console
$ npx . --help
Usage: clang-format [options] [directory]

Node.js runner for LLVM clang-format

clang-format is a tool to format C code.

If no arguments are given, the runner formats the current directory recursively.
Any clang-format configuration present on the filesystem will be honored.

--check mode is suitable for CI. --check does not attempt to format and instead
exits with a non-zero status code if the source code on disk does not match the
enforced style.

Options:
  -V, --version         output the version number
  -c, --check           check if the given files are formatted. Exit with a non-
                        zero status code if any formatting errors are found.
  --ext <extensions>    specify formattable file extensions (default: ".c,.cc,.cpp,.h")
  --ignore-path <path>  specify path of ignore file (default: ".clang-format-ignore")
  --no-ignore           disable use of ignore files and patterns
  -h, --help            display help for command
```